### PR TITLE
Appended artist to song title

### DIFF
--- a/spotify_visualiser.py
+++ b/spotify_visualiser.py
@@ -25,6 +25,7 @@ if df_created:
     df["dayname"] = df["datetime"].dt.day_name()
     df["hour"] = df["datetime"].dt.hour
     df["month"] = df["datetime"].dt.month_name()
+    df["master_metadata_track_name"] = df["master_metadata_track_name"] + " | " + df["master_metadata_album_artist_name"]
     st.dataframe(df.head())
 
     st.write("### Platforms :desktop_computer: :iphone: :video_game: :tv:")


### PR DESCRIPTION
When setting up the dataframe the song title has the artist name appended to it. This fixed the issue of multiple songs with the same title being combined when calculating the total number of listens.