### PR TITLE
Added category_orders to day and month graphs

### DIFF
--- a/spotify_visualiser.py
+++ b/spotify_visualiser.py
@@ -116,12 +116,17 @@ if df_created:
     hours_per_day_df = days_df["ms_played"].sum().to_frame()
     hours_per_day_df.reset_index(inplace=True)
     hours_per_day_df["hours"] = hours_per_day_df["ms_played"]/3600000
-    hours_per_day_fig = px.bar(hours_per_day_df, x='dayname', y='hours', title="Time in hours listened per day across entire listening history")
+    hours_per_day_fig = px.bar(hours_per_day_df, x="dayname", y="hours",
+                               category_orders={"dayname": ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"]},
+                               title="Time in hours listened per day across entire listening history")
     st.plotly_chart(hours_per_day_fig)
 
     # monthly listening time
     months_df = df_date_filtered.groupby(["month"])
     songs_per_month_df = months_df["month"].value_counts().to_frame()
     songs_per_month_df.reset_index(inplace=True)
-    songs_per_month_fig = px.bar(songs_per_month_df, x="month", y="count", title="Total number of songs played each month across listening history")
+    songs_per_month_fig = px.bar(songs_per_month_df, x="month", y="count",
+                                 category_orders={"month": ["January", "February", "March", "April", "May", "June",
+                                                            "July", "August", "September", "October", "November", "December"]},
+                                 title="Total number of songs played each month across listening history")
     st.plotly_chart(songs_per_month_fig)


### PR DESCRIPTION
I need to stop picking quick ones!

Found the category_orders option and added a list so the days and months appear in the specified order rather than alphabetically.